### PR TITLE
MNT: Add modified FastPD code to newmeshreg codebase

### DIFF
--- a/src/FastPD.cpp
+++ b/src/FastPD.cpp
@@ -1,0 +1,906 @@
+
+
+#include <iostream>
+#include <memory>
+
+#include "DiscreteModel.h"
+#include "DiscreteCostFunction.h"
+
+#include "FastPD.h"
+
+using namespace newmeshreg;
+
+//#define _METRIC_DISTANCE_
+
+#define PAIR(i,l0,l1)   (costfct->computePairwiseCost(i,l0,l1))
+#define UPDATE_BALANCE_VAR0(balance,d,h0,h1) { (balance)+=(d); (h0)+=(d); (h1)-=d; }
+#define NEW_LABEL(n) ((n)->parent && !((n)->is_sink))
+#define REV(a) ((a)+1)
+namespace FPD{
+//====================================================================================================================//
+FastPD::FastPD(std::shared_ptr<DiscreteModel> discreteModel, int max_iterations, bool copy_unary )
+: m_initial_energy(0), m_display(0), m_displayinst(0)
+{
+	//initialization of parameters and member variables
+	model             = discreteModel;
+	costfct           = model->getCostFunction();
+	m_num_nodes       = model->getNumNodes();
+	m_num_labels      = model->getNumLabels();
+	m_num_pairs       = model->getNumPairs();
+	m_max_iterations	= max_iterations;
+	pairs             = const_cast<int*>(model->getPairs());
+
+	m_time                = -1;
+	m_energy_change_time  = -1;
+
+	if ( m_num_labels >= pow(256.0f,float(sizeof(Graph::Label))) )
+	{
+		std::cout << "Change Graph::Label type (it is too small to hold all labels)" << std::endl;
+		assert(0);
+	}
+
+	children          = new Graph::node *[m_num_nodes];
+	source_nodes_tmp1 = new int[m_num_nodes];
+	source_nodes_tmp2 = new int[m_num_nodes];
+	for (int i = 0; i < m_num_nodes; i++)
+	{
+		source_nodes_tmp1[i] = -2;
+		source_nodes_tmp2[i] = -2;
+	}
+
+	// for each pair we will be adding two edges
+	const int num_edges = 2*m_num_pairs;
+
+	// initialization of graph topology
+	graph_nodes = new Graph::node[m_num_nodes*m_num_labels];
+	graph_edges  = new Graph::arc[  num_edges*m_num_labels];
+
+  // create for each label a single graph
+	graphs = new Graph *[m_num_labels];
+	for (int i = 0; i < m_num_labels; ++i)
+	{
+	  Graph::node* current_graph_nodes = &graph_nodes[m_num_nodes*i];
+	  Graph::arc*  current_graph_edges = &graph_edges[ num_edges*i];
+	  graphs[i] = new Graph(current_graph_nodes, current_graph_edges, m_num_nodes, err_fun);
+	  fillGraph( graphs[i] );
+	}
+
+	// initialize node, edge, and pair info structures
+	m_active_list = -1;
+	node_info = new Node_info[m_num_nodes];
+	createNeighbors();
+
+	// initialize height variables
+	if(copy_unary)
+	{
+		height = new Real[m_num_labels*m_num_nodes];
+		m_delete_height = true;
+	}
+	else
+	{
+	  height = costfct->getUnaryCosts();
+		m_delete_height = false;
+	}
+	// initialize balance variables
+	balance = new Real[m_num_pairs*m_num_labels];
+}
+
+//====================================================================================================================//
+FastPD::~FastPD()
+{
+	delete[] graph_nodes;
+	delete[] graph_edges;
+
+	Graph::Label i;
+	for( i = 0; i < m_num_labels; i++ )
+		delete graphs[i];
+	delete[] graphs;
+
+	delete[] node_info;
+	delete[] edge_info;
+	delete[] pair_info;
+	delete[] pairs_arr;
+
+	delete[] balance;
+	if(m_delete_height) delete[] height;
+
+	delete[] source_nodes_tmp1;
+	delete[] source_nodes_tmp2;
+	delete[] children;
+}
+
+//====================================================================================================================//
+double FastPD::run()
+{
+	double total_t = 0, total_augm = 0;
+	init_duals_primals();
+	int iter = 0;
+	while ( iter < m_max_iterations )
+	{
+		double prevm_energy = m_energy;
+		m_iterations = iter;
+
+		if ( !iter )
+		{
+			for( Graph::Label l = 0; l < m_num_labels; l++ )
+			{
+				inner_iteration( l );
+			}
+		}
+		else
+		{
+			for( Graph::Label l = 0; l < m_num_labels; l++ )
+			{
+				inner_iteration_adapted( l );
+			}
+		}
+
+		if ( prevm_energy <= m_energy )
+			break;
+
+		iter++;
+	}
+
+	return m_energy;
+}
+
+//====================================================================================================================//
+void FastPD::getLabeling(int *labeling)
+{
+  for(int p = 0; p < m_num_nodes; ++p){
+    labeling[p] = node_info[p].label;
+  }
+}
+//====================================================================================================================//
+void FastPD::init_duals_primals()
+{
+	if(m_delete_height) memcpy(height,costfct->getUnaryCosts(),sizeof(Real)*m_num_labels*m_num_nodes);
+
+	// Set initial values for primal and dual variables
+	for(int i = 0; i < m_num_nodes; i++ )
+	{
+		node_info[i].label =  0;
+		node_info[i].time  = -1;
+		node_info[i].next  = -1;
+		node_info[i].prev  = -2;
+	}
+
+	for(Graph::Label l = 0; l < m_num_labels; l++ )
+	{
+		Real *cy = &balance[m_num_pairs*l];
+		Real *ch = &height[m_num_nodes*l];
+		for(int i = 0; i < m_num_pairs; i++ )
+		{
+			ch[pairs[2*i]] += ( cy[i] = PAIR(i,l,l) );
+		}
+	}
+
+	for(int i = 0; i < m_num_pairs; i++ )
+	{
+		int id0 = edge_info[i  ].tail;
+		int id1 = edge_info[i  ].head;
+		int l0  = node_info[id0].label;
+		int l1  = node_info[id1].label;
+
+		if ( l0 != l1 )
+		{
+			Real d  = PAIR(i,l0,l1) - (balance[l0*m_num_pairs+i] - balance[l1*m_num_pairs+i] + PAIR(i,l1,l1));
+			UPDATE_BALANCE_VAR0( balance[l0*m_num_pairs+i], d, height[l0*m_num_nodes+id0], height[l0*m_num_nodes+id1] );
+		}
+
+		edge_info[i].balance = -balance[l1*m_num_pairs+i]+PAIR(i,l1,l1);
+	}
+
+	// Get initial primal function
+	m_energy = 0;
+	for(int i = 0; i < m_num_nodes; i++ )
+	{
+		node_info[i].height = height[node_info[i].label*m_num_nodes+i];
+		m_energy += node_info[i].height;
+	}
+	m_initial_energy = m_energy;
+}
+
+//====================================================================================================================//
+void FastPD::inner_iteration( Graph::Label label )
+{
+	int i;
+
+	Graph       *_graph =  graphs[label];
+	Graph::node *_nodes = &graph_nodes [m_num_nodes*label];
+	Graph::arc  *_arcs  = &graph_edges  [(m_num_pairs*label)<<1];
+	Real        *_curbalance = &balance         [m_num_pairs*label];
+
+	m_time++;
+	_graph->flow = 0;
+
+	if ( m_energy_change_time < m_time - m_num_labels )
+		return;
+
+	// Update balance and height variables
+	//
+	Arc_info  *einfo = edge_info;
+	Graph::arc *arcs = _arcs;
+	Real *curbalance = &balance[m_num_pairs*label];
+	Real *curheight = &height[m_num_nodes*label];
+	for( i = 0; i < m_num_pairs; i++, einfo++, arcs+=2, curbalance++ )
+	{
+		int l0,l1;
+		if ( (l1=node_info[einfo->head].label) != label && (l0=node_info[einfo->tail].label) != label )
+		{
+			Real delta  = PAIR(i,label,l1)+PAIR(i,l0,label)-PAIR(i,l0,l1)-PAIR(i,label,label);
+			Real delta1 = PAIR(i,label,l1)-( (*curbalance)+einfo->balance);
+			Real delta2;
+			if ( delta1 < 0 || (delta2=delta-delta1) < 0 )
+			{
+				UPDATE_BALANCE_VAR0( *curbalance, delta1, curheight[einfo->tail], curheight[einfo->head] )
+					arcs->cap = arcs->r_cap = 0;
+
+				#ifndef _METRIC_DISTANCE_
+				if ( delta < 0 ) // This may happen only for non-metric distances
+				{
+					delta = 0;
+					_nodes[einfo->head].conflict_time = m_time;
+				}
+				#endif
+
+				REV(arcs)->r_cap = delta;
+			}
+			else
+			{
+				arcs->cap = arcs->r_cap = delta1;
+				REV(arcs)->r_cap = delta2;
+			}
+		}
+		else
+		{
+			arcs->cap = arcs->r_cap = 0;
+			REV(arcs)->r_cap = 0;
+		}
+	}
+
+	Real total_cap = 0;
+	Node_info *pinfo = node_info;
+	Graph::node *nodes = _nodes;
+	for( i = 0; i < m_num_nodes; i++, pinfo++, nodes++, curheight++ )
+	{
+		Real delta = pinfo->height - (*curheight);
+		nodes->tr_cap = delta;
+		if (delta > 0) total_cap += delta;
+	}
+
+	// Run max-flow and update the primal variables
+	//
+	Graph::flowtype max_flow = _graph -> apply_maxflow(1);
+	m_energy -= (total_cap - max_flow);
+	if ( total_cap > max_flow )
+		m_energy_change_time = m_time;
+
+	curbalance = &balance[m_num_pairs*label];
+	einfo =  edge_info;
+	arcs  =  _arcs;
+	for( i = 0; i < m_num_pairs; i++, einfo++, arcs+=2, curbalance++ )
+		if ( node_info[einfo->head].label != label && node_info[einfo->tail].label != label )
+		{
+			if ( NEW_LABEL(&_nodes[einfo->head]) )
+				einfo->balance = -(*curbalance + arcs->cap - arcs->r_cap) + PAIR(i,label,label);
+		}
+		else if ( node_info[einfo->head].label != label )
+		{
+			if ( NEW_LABEL(&_nodes[einfo->head]) )
+				einfo->balance = -(*curbalance) + PAIR(i,label,label);
+		}
+
+		curheight = &height[m_num_nodes*label];
+		pinfo =  node_info;
+		nodes =  _nodes;
+		for( i = 0; i < m_num_nodes; i++, pinfo++, nodes++, curheight++ )
+		{
+			if ( pinfo->label != label )
+			{
+				if ( NEW_LABEL(nodes) )
+				{
+					#ifndef _METRIC_DISTANCE_
+					if ( nodes->conflict_time > pinfo->time )
+					{
+						int k;
+						for( k = 0; k < pinfo->numpairs; k++)
+						{
+							int pid = pinfo->pairs[k];
+							if ( pid <= 0 )
+							{
+								Pair_info *pair = &pair_info[-pid];
+								if ( !(_nodes[pair->i0].parent) || _nodes[pair->i0].is_sink)
+								{
+									Graph::Label l0 = node_info[pair->i0].label;
+									Graph::Label l1 =  pinfo->label;
+									Real delta = (PAIR(-pid,l0,label)+PAIR(-pid,label,l1)-
+										PAIR(-pid,l0,l1)-PAIR(-pid,label,label));
+									if ( delta < 0 )
+									{
+										_curbalance[-pid]  -= delta;
+										edge_info[-pid].balance = -_curbalance[-pid] + PAIR(-pid,label,label);
+										pinfo->height += delta;
+										m_energy          += delta;
+										_nodes[pair->i0].tr_cap += delta;
+									}
+								}
+							}
+						}
+					}
+					#endif
+
+					pinfo->label = label;
+					pinfo->height -= nodes->tr_cap;
+					nodes->tr_cap = 0;
+					pinfo->time = m_time;
+				}
+			}
+			*curheight = pinfo->height;
+		}
+
+		if (m_display)
+		{
+			std::vector<int> temp_labeling(m_num_nodes);
+			getLabeling(&temp_labeling[0]);
+			model->applyLabeling(&temp_labeling[0]);
+			m_display(m_displayinst);
+		}
+}
+
+//====================================================================================================================//
+void FastPD::inner_iteration_adapted( Graph::Label label )
+{
+	if ( m_iterations > 1 )
+		return track_source_linked_nodes( label );
+
+	int i;
+	Graph       *_graph =  graphs[label];
+	Graph::node *_nodes = &graph_nodes [m_num_nodes*label];
+	Graph::arc  *_arcs  = &graph_edges  [(m_num_pairs*label)<<1];
+	Real        *_curbalance = &balance         [m_num_pairs*label];
+	Real        *_curheight = &height         [m_num_nodes*label];
+
+	m_time++;
+	_graph->flow = 0;
+
+	if ( m_energy_change_time < m_time - m_num_labels )
+		return;
+
+	// Update dual vars (i.e. balance and height variables)
+	//
+	int dt = m_time - m_num_labels;
+	for( i = 0; i < m_num_pairs; i++ )
+	{
+		int i0 = pairs[ i<<1   ];
+		int i1 = pairs[(i<<1)+1];
+		if ( node_info[i0].time >= dt || node_info[i1].time >= dt )
+		{
+			Graph::arc *arc0 = &_arcs[i<<1];
+
+			if ( _curheight[i0] != node_info[i0].height )
+			{
+				Real h = _curheight[i0] - _nodes[i0].tr_cap;
+				_nodes[i0].tr_cap = node_info[i0].height - h;
+				_curheight[i0] = node_info[i0].height;
+			}
+
+			if ( _curheight[i1] != node_info[i1].height )
+			{
+				Real h = _curheight[i1] - _nodes[i1].tr_cap;
+				_nodes[i1].tr_cap = node_info[i1].height - h;
+				_curheight[i1] = node_info[i1].height;
+			}
+
+			int l0,l1;
+			if ( (l0=node_info[i0].label) != label && (l1=node_info[i1].label) != label )
+			{
+				Graph::arc *arc1 = &graph_edges[(m_num_pairs*l1+i)<<1];
+				Real y_pq =   _curbalance[i] + arc0->cap - arc0->r_cap ;
+				Real y_qp = -(balance[m_num_pairs*l1+i] + arc1->cap - arc1->r_cap) + PAIR(i,l1,l1);
+				Real delta  = (PAIR(i,label,l1)+PAIR(i,l0,label)-PAIR(i,l0,l1)-PAIR(i,label,label));
+				Real delta1 = PAIR(i,label,l1)-(y_pq+y_qp);
+				Real delta2;
+				if ( delta1 < 0 || (delta2=delta-delta1) < 0 )
+				{
+					_curbalance[i] = y_pq+delta1;
+					arc0->r_cap = arc0->cap = 0;
+
+					#ifndef _METRIC_DISTANCE_
+					if ( delta < 0 ) // This may happen only for non-metric distances
+					{
+						delta = 0;
+						_nodes[i1].conflict_time = m_time;
+					}
+					#endif
+
+					REV(arc0)->r_cap = delta;
+
+					_nodes[i0].tr_cap -= delta1;
+					_nodes[i1].tr_cap += delta1;
+				}
+				else
+				{
+					_curbalance[i] = y_pq;
+					arc0->r_cap = arc0->cap = delta1;
+					REV(arc0)->r_cap = delta2;
+				}
+			}
+			else
+			{
+				_curbalance[i] += arc0->cap - arc0->r_cap;
+				REV(arc0)->r_cap = arc0->r_cap = arc0->cap = 0;
+			}
+		}
+	}
+
+	// Run max-flow and update the primal variables
+	//
+	assert( m_iterations <= 1 );
+	Graph::flowtype max_flow = _graph -> apply_maxflow(1);
+
+	double prevm_energy = m_energy;
+	for( i = 0; i < m_num_nodes; i++ )
+	{
+		Node_info *pinfo = &node_info[i];
+		if ( NEW_LABEL(&_nodes[i]) )
+		{
+			#ifndef _METRIC_DISTANCE_
+			if ( _nodes[i].conflict_time > pinfo->time )
+			{
+				Real total_delta = 0;
+				int k;
+				for( k = 0; k < pinfo->numpairs; k++)
+				{
+					int pid = pinfo->pairs[k];
+					if ( pid <= 0 )
+					{
+						Pair_info *pair = &pair_info[-pid];
+						if ( !(_nodes[pair->i0].parent) || _nodes[pair->i0].is_sink)
+						{
+							Graph::Label l0 = node_info[pair->i0].label;
+							Graph::Label l1 =  pinfo->label;
+							Real delta = (PAIR(-pid,l0,label)+PAIR(-pid,label,l1)-
+								PAIR(-pid,l0,l1)-PAIR(-pid,label,label));
+
+							if ( delta < 0 )
+							{
+								_curbalance[-pid] -= delta;
+								total_delta  += delta;
+								_nodes[pair->i0].tr_cap += delta;
+							}
+						}
+					}
+				}
+				if ( total_delta )
+					_nodes[i].tr_cap -= total_delta;
+			}
+			#endif
+
+			pinfo->height -= _nodes[i].tr_cap;
+			m_energy          -= _nodes[i].tr_cap;
+			pinfo->time    = m_time;
+			pinfo->label   = label;
+
+			if ( pinfo->prev == -2 ) // add to active list
+			{
+				pinfo->next = m_active_list;
+				pinfo->prev = -1;
+				if (m_active_list >= 0)
+					node_info[m_active_list].prev = i;
+				m_active_list = i;
+			}
+		}
+	}
+	if ( m_energy < prevm_energy )
+		m_energy_change_time = m_time;
+
+	if (m_display)
+	{
+		std::vector<int> temp_labeling(m_num_nodes);
+		getLabeling(&temp_labeling[0]);
+		model->applyLabeling(&temp_labeling[0]);
+		m_display(m_displayinst);
+	}
+}
+
+//====================================================================================================================//
+void FastPD::track_source_linked_nodes( Graph::Label label )
+{
+	int i;
+	assert( m_iterations > 1 );
+
+	Graph       *_graph =  graphs[label];
+	Graph::node *_nodes = &graph_nodes [m_num_nodes*label];
+	Graph::arc  *_arcs  = &graph_edges  [(m_num_pairs*label)<<1];
+	Real        *_curbalance = &balance         [m_num_pairs*label];
+	Real        *_curheight = &height         [m_num_nodes*label];
+
+	m_time++;
+	_graph->flow = 0;
+
+	if ( m_energy_change_time < m_time - m_num_labels )
+		return;
+
+	int source_nodes_start1 = -1;
+	int source_nodes_start2 = -1;
+
+	int dt = m_time - m_num_labels;
+	i = m_active_list;
+	while ( i >= 0 )
+	{
+		Node_info *n = &node_info[i];
+		int i_next = n->next;
+
+		if ( n->time >= dt )
+		{
+			if ( _curheight[i] != n->height )
+			{
+				Real h = _curheight[i] - _nodes[i].tr_cap;
+				_nodes[i].tr_cap = n->height - h;
+				_curheight[i] = n->height;
+			}
+
+			if ( _nodes[i].tr_cap )
+			{
+				//assert(  _nodes[i].tr_cap < 0 );
+				_nodes[i].parent  = TERMINAL;
+				_nodes[i].is_sink = 1;
+				_nodes[i].DIST = 1;
+			}
+			else _nodes[i].parent = NULL;
+		}
+		else
+		{
+			int prev = n->prev;
+			if ( prev >= 0 )
+			{
+				node_info[prev].next = n->next;
+				if (n->next >= 0)
+					node_info[n->next].prev = prev;
+			}
+			else
+			{
+				m_active_list = n->next;
+				if ( m_active_list >= 0 )
+					node_info[m_active_list].prev = -1;
+			}
+			n->prev = -2;
+		}
+
+		i = i_next;
+	}
+
+	// Update balance and height variables.
+	//
+	i = m_active_list;
+	while ( i >= 0 )
+	{
+		Node_info *n = &node_info[i];
+		int i_next = n->next;
+
+		int k;
+		Node_info *n0,*n1;
+		for( k = 0; k < n->numpairs; k++)
+		{
+			int i0,i1,ii;
+			Pair_info *pair;
+			int pid = n->pairs[k];
+			if ( pid >= 0 )
+			{
+				pair = &pair_info[pid];
+				if ( pair->time == m_time )
+					continue;
+
+				i0 = i; i1 = pair->i1;
+				n0 = n; n1 = &node_info[i1];
+				ii = i1;
+			}
+			else
+			{
+				pid = -pid;
+				pair = &pair_info[pid];
+				if ( pair->time == m_time )
+					continue;
+
+				i1 = i; i0 = pair->i0;
+				n1 = n; n0 = &node_info[i0];
+				ii = i0;
+			}
+			pair->time = m_time;
+
+			int l0,l1;
+			Graph::arc *arc0 = &_arcs[pid<<1];
+			if ( (l0=n0->label) != label && (l1=n1->label) != label )
+			{
+				Graph::arc *arc1 = &graph_edges[(m_num_pairs*l1+pid)<<1];
+				Real y_pq =   _curbalance[pid] + arc0->cap - arc0->r_cap ;
+				Real y_qp = -(balance[m_num_pairs*l1+pid] + arc1->cap - arc1->r_cap) + PAIR(pid,l1,l1);
+				Real delta  = (PAIR(pid,label,l1)+PAIR(pid,l0,label)-PAIR(pid,l0,l1)-PAIR(pid,label,label));
+				Real delta1 = PAIR(pid,label,l1)-(y_pq+y_qp);
+				Real delta2;
+				if ( delta1 < 0 || (delta2=delta-delta1) < 0 )
+				{
+					_curbalance[pid] = y_pq+delta1;
+					arc0->r_cap = arc0->cap = 0;
+
+					#ifndef _METRIC_DISTANCE_
+					if ( delta < 0 ) // This may happen only for non-metric distances
+					{
+						delta = 0;
+						_nodes[i1].conflict_time = m_time;
+					}
+					#endif
+
+					REV(arc0)->r_cap = delta;
+
+					_nodes[i0].tr_cap -= delta1;
+					_nodes[i1].tr_cap += delta1;
+
+					if ( node_info[ii].prev == -2 && source_nodes_tmp2[ii] == -2 )
+					{
+						source_nodes_tmp2[ii] = source_nodes_start2;
+						source_nodes_start2 = ii;
+					}
+				}
+				else
+				{
+					_curbalance[pid] = y_pq;
+					arc0->r_cap = arc0->cap = delta1;
+					REV(arc0)->r_cap = delta2;
+				}
+			}
+			else
+			{
+				_curbalance[pid] += arc0->cap - arc0->r_cap;
+				REV(arc0)->r_cap = arc0->r_cap = arc0->cap = 0;
+			}
+		}
+
+		Graph::node *nd = &_nodes[i];
+		if ( nd->tr_cap > 0 )
+		{
+			nd -> is_sink = 0;
+			nd -> parent = TERMINAL;
+			nd -> DIST = 1;
+
+			_graph->set_active(nd);
+
+			source_nodes_tmp1[i] = source_nodes_start1;
+			source_nodes_start1 = i;
+		}
+		else if (nd->tr_cap < 0)
+		{
+			nd -> is_sink = 1;
+			nd -> parent = TERMINAL;
+			nd -> DIST = 1;
+		}
+		else nd -> parent = NULL;
+		//n -> TS = 0;
+
+		i = i_next;
+	}
+
+	for( i = source_nodes_start2; i >= 0; )
+	{
+		Graph::node *nd = &_nodes[i];
+		if ( nd->tr_cap > 0 )
+		{
+			nd -> is_sink = 0;
+			nd -> parent = TERMINAL;
+			nd -> DIST = 1;
+
+			_graph->set_active(nd);
+
+			source_nodes_tmp1[i] = source_nodes_start1;
+			source_nodes_start1 = i;
+		}
+		else if (nd->tr_cap < 0)
+		{
+			nd -> is_sink = 1;
+			nd -> parent = TERMINAL;
+			nd -> DIST = 1;
+		}
+		else nd -> parent = NULL;
+		//n -> TS = 0;
+
+		int tmp = i;
+		i = source_nodes_tmp2[i];
+		source_nodes_tmp2[tmp] = -2;
+	}
+
+	// Run max-flow and update primal variables
+	//
+	Graph::flowtype max_flow = _graph -> apply_maxflow(0);
+
+	double prevm_energy = m_energy;
+	int numchildren = 0;
+	for( i = source_nodes_start1; i >= 0; )
+	{
+		Graph::node *n = &_nodes[i];
+		if ( n->parent == TERMINAL )
+		{
+			Node_info *pinfo = &node_info[i];
+
+			#ifndef _METRIC_DISTANCE_
+			if ( n->conflict_time > pinfo->time )
+			{
+				Real total_delta = 0;
+				int k;
+				for( k = 0; k < pinfo->numpairs; k++)
+				{
+					int pid = pinfo->pairs[k];
+					if ( pid <= 0 )
+					{
+						Pair_info *pair = &pair_info[-pid];
+						if ( !(_nodes[pair->i0].parent) || _nodes[pair->i0].is_sink)
+						{
+							Graph::Label l0 = node_info[pair->i0].label;
+							Graph::Label l1 =  pinfo->label;
+							Real delta = (PAIR(-pid,l0,label)+PAIR(-pid,label,l1)-
+								PAIR(-pid,l0,l1)-PAIR(-pid,label,label));
+
+							if ( delta < 0 )
+							{
+								_curbalance[-pid] -= delta;
+								total_delta  += delta;
+								_nodes[pair->i0].tr_cap += delta;
+							}
+						}
+					}
+				}
+				if ( total_delta )
+					n->tr_cap -= total_delta;
+			}
+			#endif
+
+			pinfo->height   -= n->tr_cap;
+			m_energy            -= n->tr_cap;
+			pinfo->label     = label;
+			pinfo->time      =m_time;
+
+			if ( pinfo->prev == -2 ) // add to active list
+			{
+				pinfo->next = m_active_list;
+				pinfo->prev = -1;
+				if (m_active_list >= 0)
+					node_info[m_active_list].prev = i;
+				m_active_list = i;
+			}
+
+			Graph::arc *a;
+			for ( a=n->first; a; a=a->next )
+			{
+				Graph::node *ch = a->head;
+				if ( ch->parent == a->sister )
+					children[numchildren++] = ch;
+			}
+		}
+
+		int tmp = i;
+		i = source_nodes_tmp1[i];
+		source_nodes_tmp1[tmp] = -2;
+	}
+
+	for( i = 0; i < numchildren; i++ )
+	{
+		Graph::node *n = children[i];
+		unsigned int id  = ((uintptr_t)n - (uintptr_t)_nodes) / sizeof(Graph::node);
+		Node_info *pinfo = &node_info[id];
+
+		#ifndef _METRIC_DISTANCE_
+		if ( n->conflict_time > pinfo->time )
+		{
+			Real total_delta = 0;
+			int k;
+			for( k = 0; k < pinfo->numpairs; k++)
+			{
+				int pid = pinfo->pairs[k];
+				if ( pid <= 0 )
+				{
+					Pair_info *pair = &pair_info[-pid];
+					if ( !(_nodes[pair->i0].parent) || _nodes[pair->i0].is_sink)
+					{
+						Graph::Label l0 = node_info[pair->i0].label;
+						Graph::Label l1 =  pinfo->label;
+						Real delta = (PAIR(-pid,l0,label)+PAIR(-pid,label,l1)-
+							PAIR(-pid,l0,l1)-PAIR(-pid,label,label));
+
+						if ( delta < 0 )
+						{
+							_curbalance[-pid] -= delta;
+							total_delta  += delta;
+							_nodes[pair->i0].tr_cap += delta;
+						}
+					}
+				}
+			}
+			if ( total_delta )
+				n->tr_cap -= total_delta;
+		}
+		#endif
+
+		pinfo->height   -= n->tr_cap;
+		m_energy            -= n->tr_cap;
+		pinfo->label     = label;
+		pinfo->time      =m_time;
+
+		if ( pinfo->prev == -2 ) // add to active list
+		{
+			pinfo->next = m_active_list;
+			pinfo->prev = -1;
+			if (m_active_list >= 0)
+				node_info[m_active_list].prev = id;
+			m_active_list = id;
+		}
+
+		Graph::arc *a;
+		for ( a=n->first; a; a=a->next )
+		{
+			Graph::node *ch = a->head;
+			if ( ch->parent == a->sister )
+				children[numchildren++] = ch;
+		}
+	}
+
+	if ( m_energy < prevm_energy )
+		m_energy_change_time = m_time;
+}
+
+//====================================================================================================================//
+void FastPD::fillGraph( Graph *_graph )
+{
+  // does not really add the nodes but sets for
+  // each node the outgoing arc/edges to NULL
+  // and its capacity to zero
+	_graph->add_nodes();
+
+  // adds for each pair two directed edges/arcs
+  // between the participating nodes
+	_graph->add_edges( pairs, m_num_pairs );
+}
+
+//====================================================================================================================//
+void FastPD::createNeighbors()
+{
+	// Fill auxiliary structures related to neighbors
+	pairs_arr = new int[m_num_pairs*2];
+
+	for(int i = 0; i < m_num_nodes; i++ )
+		node_info[i].numpairs = 0;
+
+	for(int i = 0; i < m_num_pairs; i++ )
+	{
+		int i0 = pairs[i<<1];
+		int i1 = pairs[(i<<1)+1];
+		node_info[i0].numpairs++;
+		node_info[i1].numpairs++;
+	}
+
+	int offset = 0;
+	for(int i = 0; i < m_num_nodes; i++ )
+	{
+		node_info[i].pairs = &pairs_arr[offset];
+		offset += node_info[i].numpairs;
+		node_info[i].numpairs = 0;
+	}
+
+	pair_info = new Pair_info[m_num_pairs];
+	edge_info = new Arc_info[m_num_pairs];
+
+	for(int i = 0; i < m_num_pairs; i++ )
+	{
+		int i0 = pairs[i<<1];
+		int i1 = pairs[(i<<1)+1];
+		node_info[i0].pairs[node_info[i0].numpairs++] =  i;
+		node_info[i1].pairs[node_info[i1].numpairs++] = -i;
+
+		edge_info[i].tail = i0;
+		edge_info[i].head = i1;
+
+		pair_info[i].i0 = i0;
+		pair_info[i].i1 = i1;
+		pair_info[i].time = -1;
+	}
+}
+}

--- a/src/FastPD.h
+++ b/src/FastPD.h
@@ -1,0 +1,142 @@
+//#############################################################################
+//#
+//# FastPD Optimization (c) 2008.
+//#
+//# Original Author: Nikos Komodakis
+//# Reimplementation: Ben Glocker
+//#
+//# This is an implementation of the FastPD optimizer as described in:
+//# N. Komodakis, G. Tziritas, N. Paragios,
+//# Fast, Approximately Optimal Solutions for Single and Dynamic MRFs,
+//# IEEE Conference on Computer Vision and Pattern Recognition (CVPR), 2007.
+//#
+//# THE WORK IS ONLY FOR RESEARCH AND NON-COMMERCIAL PURPOSES. THE OPTIMIZATION
+//# CODE IS PROTECTED FROM SEVERAL US/EU/CHINA PENDING PATENT APPLICATIONS.
+//# IF YOU WOULD LIKE TO USE THIS SOFTWARE FOR COMMERCIAL PURPOSES OR LICENSING
+//# THE TECHNOLOGY, PLEASE CONTACT:
+//# ECOLE CENTRALE DE PARIS, PROF. NIKOS PARAGIOS (nikos.paragios@ecp.fr).
+//#
+//# If you intend to use this code or results obtained with it, the above
+//# mentioned paper should be cited within your publication.
+//#
+//#############################################################################
+
+#ifndef _FASTPDOPTIMIZATION_
+#define _FASTPDOPTIMIZATION_
+
+#include <math.h>
+#include <stdio.h>
+#include <assert.h>
+#include <time.h>
+#include <string.h>
+#include <vector>
+#include <memory>
+
+#include "DiscreteModel.h"
+#include "DiscreteCostFunction.h"
+
+#include "graph.h"
+
+
+namespace FPD{
+
+  class FastPD
+  {
+  public:
+    typedef Graph::Real Real;
+    typedef short TIME;
+
+		// Auxiliary data structures and variables
+    struct Node_info
+    {
+      Graph::Label label;
+      Real height;
+      TIME time;
+      int next;
+      int prev;
+      int *pairs;
+      int numpairs;
+    };
+
+    struct Pair_info
+    {
+      int i0, i1;
+      TIME time;
+    };
+
+    struct Arc_info
+    {
+      int head, tail;
+      Real balance;
+    };
+
+    FastPD( std::shared_ptr<newmeshreg::DiscreteModel> discreteModel, int max_iterations, bool copy_unary = false );
+
+    ~FastPD();
+
+    double run();
+
+    double getInitialEnergy() { return m_initial_energy; }
+
+    void getLabeling(int *labeling);
+
+    void setDisplayFunc(void (*display)(void *), void *inst) { m_display = display;  m_displayinst = inst; }
+
+    private:
+    void init_duals_primals();
+
+    void inner_iteration( Graph::Label label );
+
+    void inner_iteration_adapted( Graph::Label label );
+
+    void track_source_linked_nodes( Graph::Label label );
+
+    void fillGraph( Graph *_graph );
+
+    void createNeighbors();
+
+    std::shared_ptr<newmeshreg::DiscreteModel>	model;				///< Discrete model.
+    std::shared_ptr<newmeshreg::DiscreteCostFunction>	costfct;			///< Cost function to be minimized.
+    int				m_num_nodes;		///< Number of MRF nodes.
+    int				m_num_labels;		///< Number of labels.
+    int				m_num_pairs;		///< Number of node pairs (i.e. MRF edges).
+    int				m_max_iterations;	///< Number of maximum iterations.
+    int				*pairs;				///< Node pairs look up table.
+    int				m_iterations;		///< Iterations counter.
+
+    Real			*height;			///< Height variables.
+    Real			*balance;			///< Balance variables.
+    bool			m_delete_height;	///< Indicates whether the height variables have to be deleted in destructor.
+
+    Graph			**graphs;			///< List of all graph instances.
+    Graph::node		*graph_nodes;		///< List of graph node instances.
+    Graph::arc		*graph_edges;		///< List of graph edge instances.
+    Graph::node		**children;			///< List of all node children instances.
+    Node_info		*node_info;			///< List of node information.
+    Arc_info		*edge_info;			///< List of edge information.
+    Pair_info		*pair_info;			///< List of pair information.
+    int				*pairs_arr;
+
+    double			 m_initial_energy;	///< Initial MRF energy.
+    double			 m_energy;			///< MRF energy.
+    int				 m_time;
+    int				 m_active_list;
+    int				 m_energy_change_time;
+
+    int				*source_nodes_tmp1;
+    int				*source_nodes_tmp2;
+
+    void			(*m_display)(void *);		///< Callback function.
+    void			*m_displayinst;				///< Callback object instance.
+
+    // Assignment or copying are not allowed
+    FastPD(const FastPD &other);
+    FastPD operator=( const FastPD &other );
+
+    static void err_fun(char * msg)
+    {
+      printf("%s",msg);
+    }
+  };
+}
+#endif

--- a/src/Fusion.h
+++ b/src/Fusion.h
@@ -6,7 +6,7 @@
 #endif
 
 #include "DiscreteCostFunction.h"
-#include "FastPD2/FastPD.h"
+#include "FastPD.h"
 
 #define NUM_SWEEPS 2
 #define MAX_IMPROVEMENTS 0

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,11 +1,17 @@
 include ${FSLCONFDIR}/default.mk
 
-PROJNAME = NewMeshReg
-SOFILES  = libfsl-newmeshreg.so
-LIBS     = -lfsl-fastPD -lfsl-newimage -lfsl-miscmaths -lfsl-utils -lfsl-newresampler
-USRCXXFLAGS+= -DHAS_HOCR -fopenmp
+PROJNAME    = NewMeshReg
+SOFILES     = libfsl-newmeshreg.so
+LIBS        = -lfsl-newresampler -lfsl-newimage -lfsl-miscmaths -lfsl-utils
+USRCXXFLAGS = -fopenmp
+USRINCFLAGS = -DHAS_HOCR
+
+OBJS       = reg_tools.o meshregException.o histogram2D.o \
+             featurespace.o similarities.o DiscreteCostFunction.o \
+             DiscreteModel.o Fusion.o  mesh_registration.o \
+             rigid_costfunction.o FastPD.o graph.o
 
 all: ${SOFILES}
 
-libfsl-newmeshreg.so: reg_tools.o meshregException.o histogram2D.o featurespace.o similarities.o DiscreteCostFunction.o DiscreteModel.o Fusion.o mesh_registration.o rigid_costfunction.o
+libfsl-newmeshreg.so: ${OBJS}
 	${CXX} ${CXXFLAGS} -shared -o $@ $^ ${LDFLAGS}

--- a/src/block.h
+++ b/src/block.h
@@ -1,0 +1,268 @@
+/* block.h */
+/* Vladimir Kolmogorov (vnk@cs.cornell.edu), 2001. */
+
+/*
+	Template classes Block and DBlock
+	Implement adding and deleting items of the same type in blocks.
+
+	If there there are many items then using Block or DBlock
+	is more efficient than using 'new' and 'delete' both in terms
+	of memory and time since
+	(1) On some systems there is some minimum amount of memory
+	    that 'new' can allocate (e.g., 64), so if items are
+	    small that a lot of memory is wasted.
+	(2) 'new' and 'delete' are designed for items of varying size.
+	    If all items has the same size, then an algorithm for
+	    adding and deleting can be made more efficient.
+	(3) All Block and DBlock functions are inline, so there are
+	    no extra function calls.
+
+	Differences between Block and DBlock:
+	(1) DBlock allows both adding and deleting items,
+	    whereas Block allows only adding items.
+	(2) Block has an additional operation of scanning
+	    items added so far (in the order in which they were added).
+	(3) Block allows to allocate several consecutive
+	    items at a time, whereas DBlock can add only a single item.
+
+	Note that no constructors or destructors are called for items.
+
+	Example usage for items of type 'MyType':
+
+	///////////////////////////////////////////////////
+	#include "block.h"
+	#define BLOCK_SIZE 1024
+	typedef struct { int a, b; } MyType;
+	MyType *ptr, *array[10000];
+
+	...
+
+	Block<MyType> *block = new Block<MyType>(BLOCK_SIZE);
+
+	// adding items
+	for (int i=0; i<sizeof(array); i++)
+	{
+		ptr = block -> New();
+		ptr -> a = ptr -> b = rand();
+	}
+
+	// reading items
+	for (ptr=block->ScanFirst(); ptr; ptr=block->ScanNext())
+	{
+		printf("%d %d\n", ptr->a, ptr->b);
+	}
+
+	delete block;
+
+	...
+
+	DBlock<MyType> *dblock = new DBlock<MyType>(BLOCK_SIZE);
+	
+	// adding items
+	for (int i=0; i<sizeof(array); i++)
+	{
+		array[i] = dblock -> New();
+	}
+
+	// deleting items
+	for (int i=0; i<sizeof(array); i+=2)
+	{
+		dblock -> Delete(array[i]);
+	}
+
+	// adding items
+	for (int i=0; i<sizeof(array); i++)
+	{
+		array[i] = dblock -> New();
+	}
+
+	delete dblock;
+
+	///////////////////////////////////////////////////
+
+	Note that DBlock deletes items by marking them as
+	empty (i.e., by adding them to the list of free items),
+	so that this memory could be used for subsequently
+	added items. Thus, at each moment the memory allocated
+	is determined by the maximum number of items allocated
+	simultaneously at earlier moments. All memory is
+	deallocated only when the destructor is called.
+*/
+
+#ifndef __BLOCK_H__
+#define __BLOCK_H__
+
+#include <stdlib.h>
+
+/***********************************************************************/
+/***********************************************************************/
+/***********************************************************************/
+
+template <class Type> class Block
+{
+public:
+	/* Constructor. Arguments are the block size and
+	   (optionally) the pointer to the function which
+	   will be called if allocation failed; the message
+	   passed to this function is "Not enough memory!" */
+	Block(int size, void (*err_function)(char *) = NULL) { first = last = NULL; block_size = size; error_function = err_function; }
+
+	/* Destructor. Deallocates all items added so far */
+	~Block() { while (first) { block *next = first -> next; delete first; first = next; } }
+
+	/* Allocates 'num' consecutive items; returns pointer
+	   to the first item. 'num' cannot be greater than the
+	   block size since items must fit in one block */
+	Type *New(int num = 1)
+	{
+		Type *t;
+
+		if (!last || last->current + num > last->last)
+		{
+			if (last && last->next) last = last -> next;
+			else
+			{
+				block *next = (block *) new char [sizeof(block) + (block_size-1)*sizeof(Type)];
+				if (!next) { if (error_function) (*error_function)("Not enough memory!"); exit(1); }
+				if (last) last -> next = next;
+				else first = next;
+				last = next;
+				last -> current = & ( last -> data[0] );
+				last -> last = last -> current + block_size;
+				last -> next = NULL;
+			}
+		}
+
+		t = last -> current;
+		last -> current += num;
+		return t;
+	}
+
+	/* Returns the first item (or NULL, if no items were added) */
+	Type *ScanFirst()
+	{
+		scan_current_block = first;
+		if (!scan_current_block) return NULL;
+		scan_current_data = & ( scan_current_block -> data[0] );
+		return scan_current_data ++;
+	}
+
+	/* Returns the next item (or NULL, if all items have been read)
+	   Can be called only if previous ScanFirst() or ScanNext()
+	   call returned not NULL. */
+	Type *ScanNext()
+	{
+		if (scan_current_data >= scan_current_block -> current)
+		{
+			scan_current_block = scan_current_block -> next;
+			if (!scan_current_block) return NULL;
+			scan_current_data = & ( scan_current_block -> data[0] );
+		}
+		return scan_current_data ++;
+	}
+
+	/* Marks all elements as empty */
+	void Reset()
+	{
+		block *b;
+		if (!first) return;
+		for (b=first; ; b=b->next)
+		{
+			b -> current = & ( b -> data[0] );
+			if (b == last) break;
+		}
+		last = first;
+	}
+
+/***********************************************************************/
+
+private:
+
+	typedef struct block_st
+	{
+		Type					*current, *last;
+		struct block_st			*next;
+		Type					data[1];
+	} block;
+
+	int		block_size;
+	block	*first;
+	block	*last;
+
+	block	*scan_current_block;
+	Type	*scan_current_data;
+
+	void	(*error_function)(char *);
+};
+
+/***********************************************************************/
+/***********************************************************************/
+/***********************************************************************/
+
+template <class Type> class DBlock
+{
+public:
+	/* Constructor. Arguments are the block size and
+	   (optionally) the pointer to the function which
+	   will be called if allocation failed; the message
+	   passed to this function is "Not enough memory!" */
+	DBlock(int size, void (*err_function)(char *) = NULL) { first = NULL; first_free = NULL; block_size = size; error_function = err_function; }
+
+	/* Destructor. Deallocates all items added so far */
+	~DBlock() { while (first) { block *next = first -> next; delete first; first = next; } }
+
+	/* Allocates one item */
+	Type *New()
+	{
+		block_item *item;
+
+		if (!first_free)
+		{
+			block *next = first;
+			first = (block *) new char [sizeof(block) + (block_size-1)*sizeof(block_item)];
+			if (!first) { if (error_function) (*error_function)("Not enough memory!"); exit(1); }
+			first_free = & (first -> data[0] );
+			for (item=first_free; item<first_free+block_size-1; item++)
+				item -> next_free = item + 1;
+			item -> next_free = NULL;
+			first -> next = next;
+		}
+
+		item = first_free;
+		first_free = item -> next_free;
+		return (Type *) item;
+	}
+
+	/* Deletes an item allocated previously */
+	void Delete(Type *t)
+	{
+		((block_item *) t) -> next_free = first_free;
+		first_free = (block_item *) t;
+	}
+
+/***********************************************************************/
+
+private:
+
+	typedef union block_item_st
+	{
+		Type			t;
+		block_item_st	*next_free;
+	} block_item;
+
+	typedef struct block_st
+	{
+		struct block_st			*next;
+		block_item				data[1];
+	} block;
+
+	int			block_size;
+	block		*first;
+	block_item	*first_free;
+
+	void	(*error_function)(char *);
+};
+
+
+#endif
+

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -1,0 +1,529 @@
+/* graph.cpp */
+/* Vladimir Kolmogorov (vnk@cs.cornell.edu), 2001. */
+
+#include <stdio.h>
+#include "graph.h"
+#include <iostream>
+
+Graph::Graph(node *nodes, arc *arcs, int num_nodes, void (*err_function)(char *))
+{
+	error_function = err_function;
+	_nodes = nodes;
+	_arcs  = arcs ;
+	_num_nodes = num_nodes;
+	flow = 0;
+}
+
+Graph::~Graph()
+{
+}
+
+void Graph::add_nodes()
+{
+	for( int i = 0; i < _num_nodes; i++ )
+	{
+		_nodes[i].first = NULL;
+		_nodes[i].tr_cap = 0;
+#ifndef _METRIC_DISTANCE_
+		_nodes[i].conflict_time = -1;
+#endif
+	}
+}
+
+void Graph::add_edges(int *pairs, int numpairs )
+{
+	captype cap = 0;
+	captype rev_cap = 0;
+
+  // numpairs iterations (note i+=2)
+	for( int i = 0; i < 2*numpairs; i+=2 )
+	{
+    // retrieval of the node_id's (node*)
+		node_id from = &_nodes[pairs[i]];
+		node_id to   = &_nodes[pairs[i+1]];
+
+    // there are always two arcs inserted into the graph
+    // 'from -> to' as well as 'to -> from'
+		arc *a, *a_rev;
+
+    // retrieve the two arcs from the _arcs array
+    // the array is indexed in the same way as pairs
+    // arcs[i]   = node[pairs[i]] -> node[pairs[i+1]]
+    // arcs[i+1] = node[pairs[i+1]] -> node[pairs[i]]
+		a = &_arcs[i];
+		a_rev = a + 1;
+
+    // sister holds the reverse arcs
+		a -> sister = a_rev;
+		a_rev -> sister = a;
+
+    // next points to the next outgoing arc/edge in from
+    // since there is exactly one outgoing edge, it points
+    // to itself!
+		a -> next = ((node*)from) -> first; // i.e. a->next = a
+		((node*)from) -> first = a;
+
+    // here holds the same as above
+		a_rev -> next = ((node*)to) -> first;
+		((node*)to) -> first = a_rev;
+
+    // head is pointing to the destination node
+		a -> head = (node*)to;
+		a_rev -> head = (node*)from;
+
+    // and finally, we configure the capacities
+		a -> r_cap = cap;
+		a_rev -> r_cap = rev_cap;
+	}
+}
+
+void Graph::set_tweights(node_id i, captype cap_source, captype cap_sink)
+{
+	flow += (cap_source < cap_sink) ? cap_source : cap_sink;
+	((node*)i) -> tr_cap = cap_source - cap_sink;
+}
+
+void Graph::add_tweights(node_id i, captype cap_source, captype cap_sink)
+{
+	captype delta = ((node*)i) -> tr_cap;
+	if (delta > 0) cap_source += delta;
+	else           cap_sink   -= delta;
+	flow += (cap_source < cap_sink) ? cap_source : cap_sink;
+	((node*)i) -> tr_cap = cap_source - cap_sink;
+}
+
+/***********************************************************************/
+/* maxflow.cpp */
+/* Vladimir Kolmogorov (vnk@cs.cornell.edu), 2001. */
+/***********************************************************************/
+
+/*
+Returns the next active node.
+If it is connected to the sink, it stays in the list,
+otherwise it is removed from the list
+*/
+inline Graph::node * Graph::next_active()
+{
+	node *i;
+
+	while ( 1 )
+	{
+		if (!(i=queue_first[0]))
+		{
+			queue_first[0] = i = queue_first[1];
+			queue_last[0]  = queue_last[1];
+			queue_first[1] = NULL;
+			queue_last[1]  = NULL;
+			if (!i) return NULL;
+		}
+
+		/* remove it from the active list */
+		if (i->next == i) queue_first[0] = queue_last[0] = NULL;
+		else              queue_first[0] = i -> next;
+		i -> next = NULL;
+
+		/* a node in the list is active iff it has a parent */
+		if (i->parent) return i;
+	}
+}
+
+/***********************************************************************/
+
+void Graph::maxflow_init()
+{
+	node *i;
+
+	queue_first[0] = queue_last[0] = NULL;
+	queue_first[1] = queue_last[1] = NULL;
+	orphan_first = NULL;
+
+	int k;
+	for( k = 0, i = _nodes; k < _num_nodes; k++, i++ )
+	{
+		i -> next = NULL;
+		i -> TS = 0;
+		if (i->tr_cap > 0)
+		{
+			/* i is connected to the source */
+			i -> is_sink = 0;
+			i -> parent = TERMINAL;
+			set_active(i);
+			i -> TS = 0;
+			i -> DIST = 1;
+		}
+		else if (i->tr_cap < 0)
+		{
+			/* i is connected to the sink */
+			i -> is_sink = 1;
+			i -> parent = TERMINAL;
+			i -> TS = 0;
+			i -> DIST = 1;
+		}
+		else
+		{
+			i -> parent = NULL;
+		}
+	}
+	TIME = 0;
+}
+
+/***********************************************************************/
+
+void Graph::augment(arc *middle_arc)
+{
+	node *i;
+	arc *a;
+	captype bottleneck;
+	nodeptr *np;
+
+
+	/* 1. Finding bottleneck capacity */
+	/* 1a - the source tree */
+	bottleneck = middle_arc -> r_cap;
+	for (i=middle_arc->sister->head; ; i=a->head)
+	{
+		a = i -> parent;
+		if (a == TERMINAL) break;
+		if (bottleneck > a->sister->r_cap) bottleneck = a -> sister -> r_cap;
+	}
+	if (bottleneck > i->tr_cap) bottleneck = i -> tr_cap;
+	/* 1b - the sink tree */
+	for (i=middle_arc->head; ; i=a->head)
+	{
+		a = i -> parent;
+		if (a == TERMINAL) break;
+		if (bottleneck > a->r_cap) bottleneck = a -> r_cap;
+	}
+	if (bottleneck > - i->tr_cap) bottleneck = - i -> tr_cap;
+
+
+	/* 2. Augmenting */
+	/* 2a - the source tree */
+	middle_arc -> sister -> r_cap += bottleneck;
+	middle_arc -> r_cap -= bottleneck;
+	for (i=middle_arc->sister->head; ; i=a->head)
+	{
+		a = i -> parent;
+		if (a == TERMINAL) break;
+		a -> r_cap += bottleneck;
+		a -> sister -> r_cap -= bottleneck;
+		if (!a->sister->r_cap)
+		{
+			/* add i to the adoption list */
+			i -> parent = ORPHAN;
+			np = nodeptr_block -> New();
+			np -> ptr = i;
+			np -> next = orphan_first;
+			orphan_first = np;
+		}
+	}
+	i -> tr_cap -= bottleneck;
+	if (!i->tr_cap)
+	{
+		/* add i to the adoption list */
+		i -> parent = ORPHAN;
+		np = nodeptr_block -> New();
+		np -> ptr = i;
+		np -> next = orphan_first;
+		orphan_first = np;
+	}
+	/* 2b - the sink tree */
+	for (i=middle_arc->head; ; i=a->head)
+	{
+		a = i -> parent;
+		if (a == TERMINAL) break;
+		a -> sister -> r_cap += bottleneck;
+		a -> r_cap -= bottleneck;
+		if (!a->r_cap)
+		{
+			/* add i to the adoption list */
+			i -> parent = ORPHAN;
+			np = nodeptr_block -> New();
+			np -> ptr = i;
+			np -> next = orphan_first;
+			orphan_first = np;
+		}
+	}
+	i -> tr_cap += bottleneck;
+	if (!i->tr_cap)
+	{
+		i->parent = NULL;
+	}
+
+	flow += bottleneck;
+}
+
+/***********************************************************************/
+
+void Graph::process_source_orphan(node *i)
+{
+	node *j;
+	arc *a0, *a0_min = NULL, *a;
+	nodeptr *np;
+	int d, d_min = INFINITE_D;
+
+	/* trying to find a new parent */
+	for (a0=i->first; a0; a0=a0->next)
+		if (a0->sister->r_cap)
+		{
+			j = a0 -> head;
+			if (!j->is_sink && (a=j->parent))
+			{
+				/* checking the origin of j */
+				d = 0;
+				while ( 1 )
+				{
+					if (j->TS == TIME)
+					{
+						d += j -> DIST;
+						break;
+					}
+					a = j -> parent;
+					d ++;
+					if (a==TERMINAL)
+					{
+						j -> TS = TIME;
+						j -> DIST = 1;
+						break;
+					}
+					if (a==ORPHAN) { d = INFINITE_D; break; }
+					j = a -> head;
+				}
+				if (d<INFINITE_D) /* j originates from the source - done */
+				{
+					if (d<d_min)
+					{
+						a0_min = a0;
+						d_min = d;
+					}
+					/* set marks along the path */
+					for (j=a0->head; j->TS!=TIME; j=j->parent->head)
+					{
+						j -> TS = TIME;
+						j -> DIST = d --;
+					}
+				}
+			}
+		}
+
+		if (i->parent = a0_min)
+		{
+			i -> TS = TIME;
+			i -> DIST = d_min + 1;
+		}
+		else
+		{
+			/* no parent is found */
+			i -> TS = 0;
+
+			/* process neighbors */
+			for (a0=i->first; a0; a0=a0->next)
+			{
+				j = a0 -> head;
+				if (!j->is_sink && (a=j->parent))
+				{
+					if (a0->sister->r_cap) set_active(j);
+					if (a!=TERMINAL && a!=ORPHAN && a->head==i)
+					{
+						/* add j to the adoption list */
+						j -> parent = ORPHAN;
+						np = nodeptr_block -> New();
+						np -> ptr = j;
+						if (orphan_last) orphan_last -> next = np;
+						else             orphan_first        = np;
+						orphan_last = np;
+						np -> next = NULL;
+					}
+				}
+			}
+		}
+}
+
+void Graph::process_sink_orphan(node *i)
+{
+	node *j;
+	arc *a0, *a0_min = NULL, *a;
+	nodeptr *np;
+	int d, d_min = INFINITE_D;
+
+	/* trying to find a new parent */
+	for (a0=i->first; a0; a0=a0->next)
+		if (a0->r_cap)
+		{
+			j = a0 -> head;
+			if (j->is_sink && (a=j->parent))
+			{
+				/* checking the origin of j */
+				d = 0;
+				while ( 1 )
+				{
+					if (j->TS == TIME)
+					{
+						d += j -> DIST;
+						break;
+					}
+					a = j -> parent;
+					d ++;
+					if (a==TERMINAL)
+					{
+						j -> TS = TIME;
+						j -> DIST = 1;
+						break;
+					}
+					if (a==ORPHAN) { d = INFINITE_D; break; }
+					j = a -> head;
+				}
+				if (d<INFINITE_D) /* j originates from the sink - done */
+				{
+					if (d<d_min)
+					{
+						a0_min = a0;
+						d_min = d;
+					}
+					/* set marks along the path */
+					for (j=a0->head; j->TS!=TIME; j=j->parent->head)
+					{
+						j -> TS = TIME;
+						j -> DIST = d --;
+					}
+				}
+			}
+		}
+
+		if (i->parent = a0_min)
+		{
+			i -> TS = TIME;
+			i -> DIST = d_min + 1;
+		}
+		else
+		{
+			/* no parent is found */
+			i -> TS = 0;
+
+			/* process neighbors */
+			for (a0=i->first; a0; a0=a0->next)
+			{
+				j = a0 -> head;
+				if (j->is_sink && (a=j->parent))
+				{
+					if (a0->r_cap) set_active(j);
+					if (a!=TERMINAL && a!=ORPHAN && a->head==i)
+					{
+						/* add j to the adoption list */
+						j -> parent = ORPHAN;
+						np = nodeptr_block -> New();
+						np -> ptr = j;
+						if (orphan_last) orphan_last -> next = np;
+						else             orphan_first        = np;
+						orphan_last = np;
+						np -> next = NULL;
+					}
+				}
+			}
+		}
+}
+
+/***********************************************************************/
+
+Graph::flowtype Graph::apply_maxflow( int init_on )
+{
+	node *i, *j, *current_node = NULL;
+	arc *a;
+	nodeptr *np, *np_next;
+
+	if ( init_on )
+		maxflow_init();
+	nodeptr_block = new DBlock<nodeptr>(NODEPTR_BLOCK_SIZE, error_function);
+
+	//int num_iter = 0;					//ADDED BY BEN
+	//while ( num_iter < 10000 )		//ADDED BY BEN
+
+	while ( 1 )
+	{
+		//num_iter++;					//ADDED BY BEN
+
+		if (i=current_node)
+		{
+			i -> next = NULL; /* remove active flag */
+			if (!i->parent) i = NULL;
+		}
+		if (!i)
+		{
+			if (!(i = next_active())) break;
+		}
+
+		/* growth */
+		if (!i->is_sink)
+		{
+			/* grow source tree */
+			for (a=i->first; a; a=a->next)
+				if (a->r_cap)
+				{
+					j = a -> head;
+					if (!j->parent)
+					{
+						j -> is_sink = 0;
+						j -> parent = a -> sister;
+						j -> TS = i -> TS;
+						j -> DIST = i -> DIST + 1;
+						set_active(j);
+					}
+					else if (j->is_sink) break;
+					else if (j->TS <= i->TS &&
+						j->DIST > i->DIST)
+					{
+						/* heuristic - trying to make the distance from j to the source shorter */
+						j -> parent = a -> sister;
+						j -> TS = i -> TS;
+						j -> DIST = i -> DIST + 1;
+					}
+				}
+		}
+		else a = NULL;
+
+		TIME ++;
+
+		if (a)
+		{
+			i -> next = i; /* set active flag */
+			current_node = i;
+
+			/* augmentation */
+			augment(a);
+			/* augmentation end */
+
+			/* adoption */
+			while (np=orphan_first)
+			{
+				np_next = np -> next;
+				np -> next = NULL;
+
+				while (np=orphan_first)
+				{
+					orphan_first = np -> next;
+					i = np -> ptr;
+					nodeptr_block -> Delete(np);
+					if (!orphan_first) orphan_last = NULL;
+					if (i->is_sink) process_sink_orphan(i);
+					else            process_source_orphan(i);
+				}
+
+				orphan_first = np_next;
+			}
+			/* adoption end */
+		}
+		else current_node = NULL;
+	}
+
+	delete nodeptr_block;
+
+	return flow;
+}
+
+/***********************************************************************/
+
+Graph::termtype Graph::what_segment(node_id i)
+{
+	if (((node*)i)->parent && !((node*)i)->is_sink) return SOURCE;
+	return SINK;
+}

--- a/src/graph.h
+++ b/src/graph.h
@@ -1,0 +1,296 @@
+//#############################################################################
+//#
+//# FastPD Optimization (c) 2008.
+//#
+//# Max-flow Computation.
+//#
+//# Original Author: Vladimir Kolmogorov
+//# Modification: Nikos Komodakis
+//#
+//# This is an implementation of the modified max-flow computation described in:
+//# N. Komodakis, G. Tziritas, N. Paragios,
+//# Fast, Approximately Optimal Solutions for Single and Dynamic MRFs,
+//# IEEE Conference on Computer Vision and Pattern Recognition (CVPR), 2007.
+//#
+//# THE WORK IS ONLY FOR RESEARCH AND NON-COMMERCIAL PURPOSES. THE OPTIMIZATION
+//# CODE IS PROTECTED FROM SEVERAL US/EU/CHINA PENDING PATENT APPLICATIONS.
+//# IF YOU WOULD LIKE TO USE THIS SOFTWARE FOR COMMERCIAL PURPOSES OR LICENSING
+//# THE TECHNOLOGY, PLEASE CONTACT:
+//# ECOLE CENTRALE DE PARIS, PROF. NIKOS PARAGIOS (nikos.paragios@ecp.fr).
+//#
+//# If you intend to use this code or results obtained with it, the above
+//# mentioned paper should be cited within your publication.
+//#
+//#############################################################################
+
+//#############################################################################
+//# Header for the original max-flow computation by Yuri Boykov and
+//# Vladimir Kolmogorov.
+//#############################################################################
+/* graph.h */
+/* Vladimir Kolmogorov (vnk@cs.cornell.edu), 2001. */
+
+/*
+	This software library is a modification of the maxflow algorithm
+	described in
+
+	An Experimental Comparison of Min-Cut/Max-Flow Algorithms
+	for Energy Minimization in Computer Vision.
+	Yuri Boykov and Vladimir Kolmogorov.
+	In Third International Workshop on Energy Minimization
+	Methods in Computer Vision and Pattern Recognition, September 2001
+
+	This algorithm was originally developed at Siemens.
+	The main modification is that two trees are used for finding
+	augmenting paths - one grows from the source and the other
+	from the sink. (The original algorithm used only the former one).
+	Details will be described in my PhD thesis.
+
+	This implementation uses an adjacency list graph representation.
+	Memory allocation:
+		Nodes: 22 bytes + one field to hold a residual capacity
+		       of t-links (by default it is 'short' - 2 bytes)
+		Arcs: 12 bytes + one field to hold a residual capacity
+		      (by default it is 'short' - 2 bytes)
+	(Note that arcs are always added in pairs - in forward and reverse directions)
+
+	Example usage (computes a maxflow on the following graph):
+
+		        SOURCE
+		       /       \
+		     1/         \2
+		     /      3    \
+		   node0 -----> node1
+		     |   <-----   |
+		     |      4     |
+		     \            /
+		     5\          /6
+		       \        /
+		          SINK
+
+	///////////////////////////////////////////////////
+
+	#include <stdio.h>
+	#include "graph.h"
+
+	void main()
+	{
+		Graph::node_id nodes[2];
+		Graph *g = new Graph();
+
+		nodes[0] = g -> add_node();
+		nodes[1] = g -> add_node();
+		g -> set_tweights(nodes[0], 1, 5);
+		g -> set_tweights(nodes[1], 2, 6);
+		g -> add_edge(nodes[0], nodes[1], 3, 4);
+
+		Graph::flowtype flow = g -> maxflow();
+
+		printf("Flow = %d\n", flow);
+		printf("Minimum cut:\n");
+		if (g->what_segment(nodes[0]) == Graph::SOURCE)
+			printf("node0 is in the SOURCE set\n");
+		else
+			printf("node0 is in the SINK set\n");
+		if (g->what_segment(nodes[1]) == Graph::SOURCE)
+			printf("node1 is in the SOURCE set\n");
+		else
+			printf("node1 is in the SINK set\n");
+
+		delete g;
+	}
+
+	///////////////////////////////////////////////////
+*/
+
+#ifndef __GRAPH_H__
+#define __GRAPH_H__
+
+#include "block.h"
+
+/*
+	Nodes, arcs and pointers to nodes are
+	added in blocks for memory and time efficiency.
+	Below are numbers of items in blocks
+*/
+#define NODE_BLOCK_SIZE 512
+#define ARC_BLOCK_SIZE 1024
+#define NODEPTR_BLOCK_SIZE 128
+
+/*
+	special constants for node->parent
+*/
+#define TERMINAL ( (Graph::arc *) 1 )		/* to terminal */
+#define ORPHAN   ( (Graph::arc *) 2 )		/* orphan */
+
+#define INFINITE_D 1000000000		/* infinite distance to the terminal */
+
+class Graph
+{
+public:
+
+#define _MANY_LABELS_
+#ifdef _MANY_LABELS_
+	typedef int Label;
+#else
+	typedef unsigned char Label;
+#endif
+
+	typedef enum
+	{
+		SOURCE	= 0,
+		SINK	= 1
+	} termtype; /* terminals */
+
+	/* Type of edge weights.
+	   Can be changed to char, int, float, double, ... */
+	typedef double captype;  
+	typedef captype Real;
+
+	/* Type of total flow */
+	typedef float flowtype;
+
+	typedef void * node_id;
+
+	/* interface functions */
+
+	/* Destructor */
+	~Graph();
+
+	/* Adds a node to the graph */
+	void add_nodes();
+
+	/* Adds a bidirectional edge between 'from' and 'to'
+	   with the weights 'cap' and 'rev_cap' */
+	void add_edges( int *pairs, int numpairs );
+
+	/* Sets the weights of the edges 'SOURCE->i' and 'i->SINK'
+	   Can be called at most once for each node before any call to 'add_tweights'.
+	   Weights can be negative */
+	void set_tweights(node_id i, captype cap_source, captype cap_sink);
+
+	/* Adds new edges 'SOURCE->i' and 'i->SINK' with corresponding weights
+	   Can be called multiple times for each node.
+	   Weights can be negative */
+	void add_tweights(node_id i, captype cap_source, captype cap_sink);
+
+	/* After the maxflow is computed, this function returns to which
+	   segment the node 'i' belongs (Graph::SOURCE or Graph::SINK) */
+	termtype what_segment(node_id i);
+
+	/* Computes the maxflow. Can be called only once. */
+	flowtype apply_maxflow( int track_source_nodes );
+
+/***********************************************************************/
+/***********************************************************************/
+/***********************************************************************/
+	
+	/* internal variables and functions */
+
+	struct arc_st;
+
+	/* node structure */
+	typedef struct node_st
+	{
+		arc_st			*first;		/* first outcoming arc */
+
+		arc_st			*parent;	/* node's parent */
+		node_st			*next;		/* pointer to the next active node
+									   (or to itself if it is the last node in the list) */
+		int				TS;			/* timestamp showing when DIST was computed */
+		int				DIST;		/* distance to the terminal */
+		short			is_sink;	/* flag showing whether the node is in the source or in the sink tree */
+
+		captype			tr_cap;		/* if tr_cap > 0 then tr_cap is residual capacity of the arc SOURCE->node
+									   otherwise         -tr_cap is residual capacity of the arc node->SINK */
+#ifndef _METRIC_DISTANCE_
+		short            conflict_time;
+#endif
+	} node;
+
+	/* arc structure */
+	typedef struct arc_st           // arc pq
+	{
+		node_st			*head;		/* node q, i.e. node the arc points to */
+		arc_st			*next;		/* next arc with the same originating node */
+		arc_st			*sister;	/* arc qp, i.e. reverse arc */
+
+		captype			r_cap;		/* residual capacity */
+
+		Real            cap;        // cap_{pq}   
+	} arc;
+
+	/* 'pointer to node' structure */
+	typedef struct nodeptr_st
+	{
+		node_st			*ptr;
+		nodeptr_st		*next;
+	} nodeptr;
+
+	Block<node>			*node_block;
+	Block<arc>			*arc_block;
+	DBlock<nodeptr>		*nodeptr_block;
+
+	void	(*error_function)(char *);	/* this function is called if a error occurs,
+										   with a corresponding error message
+										   (or exit(1) is called if it's NULL) */
+
+	flowtype			flow;		    /* total flow */
+
+	/* Constructor. Optional argument is the pointer to the
+	   function which will be called if an error occurs;
+	   an error message is passed to this function. If this
+	   argument is omitted, exit(1) will be called. */
+	Graph(node *nodes, arc *arcs, int num_nodes, void (*err_function)(char *) = NULL);
+
+	void reset_flow( void )
+	{
+		flow = 0;
+	}
+
+	arc                *_arcs;
+	node               *_nodes;
+	int                 _num_nodes;
+
+//private:
+
+/***********************************************************************/
+
+	node				*queue_first[2], *queue_last[2];	/* list of active nodes */
+	nodeptr				*orphan_first, *orphan_last;		/* list of pointers to orphans */
+	int					TIME;								/* monotonically increasing global counter */
+
+/***********************************************************************/
+
+	/*
+	Functions for processing active list.
+	i->next points to the next node in the list
+	(or to i, if i is the last node in the list).
+	If i->next is NULL iff i is not in the list.
+
+	There are two queues. Active nodes are added
+	to the end of the second queue and read from
+	the front of the first queue. If the first queue
+	is empty, it is replaced by the second queue
+	(and the second queue becomes empty).
+	*/
+	inline void set_active(node *i)
+	{
+		if (!i->next)
+		{
+			/* it's not in the list yet */
+			if (queue_last[1]) queue_last[1] -> next = i;
+			else               queue_first[1]        = i;
+			queue_last[1] = i;
+			i -> next = i;
+		}
+	}
+	node *next_active();
+
+	void maxflow_init();
+	void augment(arc *middle_arc);
+	void process_source_orphan(node *i);
+	void process_sink_orphan(node *i);
+};
+
+#endif

--- a/src/rigid_costfunction.h
+++ b/src/rigid_costfunction.h
@@ -11,7 +11,7 @@
 #ifdef HAS_HOCR
 #include "Fusion.h"
 #else
-#include <FastPD/FastPD.h>
+#include <FastPD.h>
 #endif
 
 namespace newmeshreg {


### PR DESCRIPTION
At the moment, the `FastPD` and `newmeshreg` codebases are circularly dependent on each other, and the former is going to be phased out eventually. So it makes sense to build them as a single package. Both `FastPD` and `newmeshreg` object files are compiled into a single shared library, `libfsl-newmeshreg.so`